### PR TITLE
Improve the percentage calculation

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -103,39 +103,17 @@ namespace PanicSystem
 			float percentStructure = PercentForStructureLocation(mech, LocationStructure);
 
 			float percentLocation = percentStructure;
-			float numAdditions = 1;
+			float numAdditions = 2;
 
-			// If the structure is damaged, then use that over any armor values
-			// If an armor value is lower than the structure percent, then factor it in too
+			// Use the minimum percentage between structure and armor
 			// This emphasizes internal damage from a blow through (back armor gone or tandem weapons)
-			if (percentStructure < 1)
-			{
-				if (percentFront < percentStructure)
-				{
-					percentLocation += percentFront;
-					numAdditions++;
-				}
+			percentLocation += Math.Min(percentFront, percentStructure);
 
-				if (LocationBack != 0)
-				{
-					if (percentBack < percentStructure)
-					{
-						percentLocation += percentBack;
-						numAdditions++;
-					}
-				}
-			}
-			else
+			if (LocationBack != 0)
 			{
-				percentLocation += percentFront;
-				numAdditions++;
-
-				if (LocationBack != 0)
-				{
-					percentLocation += percentBack;
-					numAdditions++;
-				}
-			}
+                percentLocation += Math.Min(percentBack, percentStructure);
+                numAdditions++;
+ 			}
 
 			percentLocation /= numAdditions;
 			return percentLocation;


### PR DESCRIPTION
My original design would ignore the front/back armor if the structure is lower, but it should simply use the minimum of both and still consider it.
For example:  FA 100% / BA 0% / Struct 50%
Old = ignore + 0 + 50 / 2 = 25%
New = 50 + 0 + 50 / 3 = 33%

If the FA % is slightly lower than the structure, in the old design you would panic less than if the FA were full.
FA 49% / BA 0% / Struct 50%
Old = 49 + 0 + 50 / 3 = 33% (very similar result to the new design)